### PR TITLE
feat: add vercel analytics and update speed insights

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Syne, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 
@@ -33,6 +34,7 @@ export default function RootLayout({
         className={`${syne.variable} ${geistMono.variable} font-sans antialiased`}
       >
         {children}
+        <Analytics />
         <SpeedInsights />
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "framer-motion": "^12.35.1",
         "lucide-react": "^0.468.0",
@@ -2193,6 +2194,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/speed-insights": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e:carousel": "playwright test tests/carousel.spec.ts --project=chromium"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "framer-motion": "^12.35.1",
     "lucide-react": "^0.468.0",


### PR DESCRIPTION
## Summary
- add @vercel/analytics dependency
- keep @vercel/speed-insights up to date
- render <Analytics /> in app/layout.tsx alongside <SpeedInsights />

## Validation
- npm --prefix /Users/adross/dev/dinhio/dinhstudio/.worktrees/vercel-analytics-speed-insights run lint
